### PR TITLE
追加 作成ボタン押した後、URLパラメータが利用可能になるまで待つ処理追加

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,6 +13,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { useRouter } from 'next/router';
 
 
+
 const defaultTheme = createTheme();
 const theme = createTheme({
   typography: {

--- a/src/pages/result/index.js
+++ b/src/pages/result/index.js
@@ -11,6 +11,9 @@ export default function ResultPage() {
     setCurrentURL(window.location.href);
   }, []);
 
+  // router.isReady が true になるまで待つ
+  if (!router.isReady) return null;
+
   return (
     <div>
       <img src={imageUrl} alt="Generated" />


### PR DESCRIPTION
# 説明
本番環境においてPC上で作成ボタンを押して、結果画面に遷移した場合に画像が表示されないバグが発生。
URLパラメータが利用可能になるまで表示を待つように記述した。

# 確認したこと
ローカルでは元々起こっていなかったバグなので本番環境で確認する。