### PR TITLE
追加  Twitterウィンドウ開くまでに待ち時間追加

### DIFF
--- a/src/pages/result/[id].js
+++ b/src/pages/result/[id].js
@@ -15,7 +15,6 @@ const StyledLink = styled(Link)(({ theme }) => ({
   textAlign: 'center', 
 }));
 
-
 export default function ResultPage({ imageText }) {
   const router = useRouter();
   const { id, shared } = router.query; 
@@ -32,11 +31,14 @@ export default function ResultPage({ imageText }) {
   const [open, setOpen] = useState(false);
 
   const handleOpen = () => {
-    window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent('わたしのプロフィール！みんなよろしく♪ #りーどみー #RUNTEQ #大人のプロフィール帳')}`, '_blank');
-    setOpen(true);
+    setTimeout(() => {
+      window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent('わたしのプロフィール！みんなよろしく♪ #りーどみー #RUNTEQ #大人のプロフィール帳')}`, '_blank');
+      setOpen(true);
+    }, 700); 
   };
 
   const handleClose = () => setOpen(false);
+
 
   return (
     <>


### PR DESCRIPTION
# 説明
Twitterでリンクを共有する際にOGP画像が読み込まれないバグが発生。
共有するボタンを押してから待ち時間を追加。

# 確認したこと
自分の環境では元々エラーが発生していないので、ユーザーに使ってもらう。
