### PR TITLE
28 section2

### DIFF
--- a/src/pages/mypage/[id].js
+++ b/src/pages/mypage/[id].js
@@ -3,9 +3,9 @@ import { Box, CardMedia, CardContent, Grid, Card, IconButton, Modal, Button, Typ
 import { styled } from '@mui/system';
 import nookies from "nookies";
 import axios from 'axios';
-import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
-import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
-import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
+// import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
+// import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
+// import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import LockIcon from '@mui/icons-material/Lock';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Select from '@mui/material/Select';
@@ -51,9 +51,9 @@ export default function ProfilePage() {
   const [userCommunities, setUserCommunities] = useState([]);
   const [openRanges, setOpenRanges] = useState([]);
 
-  const [openModalHeart, setOpenModalHeart] = useState(false);
-  const [openModalStar, setOpenModalStar] = useState(false);
-  const [openModalChat, setOpenModalChat] = useState(false);
+  // const [openModalHeart, setOpenModalHeart] = useState(false);
+  // const [openModalStar, setOpenModalStar] = useState(false);
+  // const [openModalChat, setOpenModalChat] = useState(false);
 
 
   const shareUrl = `https://readmeee.vercel.app/profiles/${id}?shared=true`;
@@ -219,29 +219,29 @@ export default function ProfilePage() {
       };
 
   
-const handleOpenModalHeart = () => {
-  setOpenModalHeart(true);
-};
+// const handleOpenModalHeart = () => {
+//   setOpenModalHeart(true);
+// };
 
-const handleCloseModalHeart = () => {
-  setOpenModalHeart(false);
-};
+// const handleCloseModalHeart = () => {
+//   setOpenModalHeart(false);
+// };
 
-const handleOpenModalStar = () => {
-  setOpenModalStar(true);
-};
+// const handleOpenModalStar = () => {
+//   setOpenModalStar(true);
+// };
 
-const handleCloseModalStar = () => {
-  setOpenModalStar(false);
-};
+// const handleCloseModalStar = () => {
+//   setOpenModalStar(false);
+// };
 
-const handleOpenModalChat = () => {
-  setOpenModalChat(true);
-};
+// const handleOpenModalChat = () => {
+//   setOpenModalChat(true);
+// };
 
-const handleCloseModalChat = () => {
-  setOpenModalChat(false);
-};
+// const handleCloseModalChat = () => {
+//   setOpenModalChat(false);
+// };
 
 
   return (
@@ -257,7 +257,7 @@ const handleCloseModalChat = () => {
         </StyledCard>
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <IconCard>
-            <Tooltip title="いいね">
+            {/* <Tooltip title="いいね">
               <IconButton onClick={handleOpenModalHeart}>
                 <FavoriteBorderOutlinedIcon sx={{ color: 'Red' }} />
               </IconButton>
@@ -271,7 +271,7 @@ const handleCloseModalChat = () => {
               <IconButton onClick={handleOpenModalChat}>
                 <ChatBubbleOutlineOutlinedIcon sx={{ color: 'gray' }} />
               </IconButton>
-            </Tooltip>
+            </Tooltip> */}
             <Tooltip title="公開範囲の設定">
               <IconButton onClick={handleOpenModalForOpenRange}>
                 <LockIcon sx={{ color: '#ffd700' }} />
@@ -377,7 +377,7 @@ const handleCloseModalChat = () => {
         </Box>
       </Box>
     </Modal>
-    <Modal
+    {/* <Modal
   open={openModalHeart}
   onClose={handleCloseModalHeart}
 >
@@ -425,7 +425,7 @@ const handleCloseModalChat = () => {
                   p: 4,
                 }}>準備中です！
        </Box>
-      </Modal>
+      </Modal> */}
     </>
   );
 }

--- a/src/pages/mypage/edit.js
+++ b/src/pages/mypage/edit.js
@@ -195,6 +195,13 @@ export default function AdditionalInfoPage() {
               value={selectedGroup}
               onChange={handleGroupChange}
               fullWidth
+              MenuProps={{ 
+                PaperProps: {
+                  style: {
+                    maxHeight: '200px', 
+                  },
+                },
+              }}
             >
               {groups.map((group) => (
                 <MenuItem key={group.id} value={group.id}>{group.name}</MenuItem>

--- a/src/pages/mypage/index.js
+++ b/src/pages/mypage/index.js
@@ -9,25 +9,25 @@ import { styled } from '@mui/system';
 import CenteredBox from '../../components/CenteredBox';
 import { useAuthContext } from '../../context/AuthContext';
 
-const TabPanel = (props) => {
-  const { children, value, index, ...other } = props;
+// const TabPanel = (props) => {
+//   const { children, value, index, ...other } = props;
 
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      {...other}
-    >
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-}
+//   return (
+//     <div
+//       role="tabpanel"
+//       hidden={value !== index}
+//       id={`simple-tabpanel-${index}`}
+//       aria-labelledby={`simple-tab-${index}`}
+//       {...other}
+//     >
+//       {value === index && (
+//         <Box sx={{ p: 3 }}>
+//           {children}
+//         </Box>
+//       )}
+//     </div>
+//   );
+// }
 
 const StyledCard = styled(Card)(({ theme }) => ({
   width: 280, 
@@ -76,9 +76,9 @@ const MyPage = () => {
 
   //どのタブが現在アクティブであるかを管理している。
   //ユーザーが切り替えたタブを追跡し、表示するコンテンツを更新する
-  const handleChange = (event, newValue) => {  
-    setValue(newValue); 
-  };
+  // const handleChange = (event, newValue) => {  
+  //   setValue(newValue); 
+  // };
 
   const handleCardClick = (profile) => {
     router.push(`/mypage/${profile.uuid}`);
@@ -183,12 +183,12 @@ const MyPage = () => {
       </TableContainer>
     </Box>
 
-    <Tabs value={value} onChange={handleChange} centered>
+    {/* <Tabs value={value} onChange={handleChange} centered>
       <Tab  label="プロフィール帳" />
       <Tab label="お気に入り" />
-    </Tabs>
+    </Tabs> */}
 
-    <TabPanel value={value} index={0}>
+    {/* <TabPanel value={value} index={0}> */}
       <CardContent>
       {isLoading ? (
         <Skeleton variant="rectangular" width={280} height={180} />
@@ -215,13 +215,13 @@ const MyPage = () => {
         </Grid>
       )}
       </CardContent>
-    </TabPanel>
+    {/* </TabPanel> */}
 
-    <TabPanel value={value} index={1}>
+    {/* <TabPanel value={value} index={1}>
       <CardContent>
         準備中です！
       </CardContent>
-    </TabPanel>
+    </TabPanel> */}
     </>
   );
 };

--- a/src/pages/users/[id].js
+++ b/src/pages/users/[id].js
@@ -7,25 +7,25 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { styled } from '@mui/system';
 
-const TabPanel = (props) => {
-  const { children, value, index, ...other } = props;
+// const TabPanel = (props) => {
+//   const { children, value, index, ...other } = props;
 
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      {...other}
-    >
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-}
+//   return (
+//     <div
+//       role="tabpanel"
+//       hidden={value !== index}
+//       id={`simple-tabpanel-${index}`}
+//       aria-labelledby={`simple-tab-${index}`}
+//       {...other}
+//     >
+//       {value === index && (
+//         <Box sx={{ p: 3 }}>
+//           {children}
+//         </Box>
+//       )}
+//     </div>
+//   );
+// }
 
 const StyledCard = styled(Card)(({ theme }) => ({
   width: 280, 
@@ -82,9 +82,9 @@ const UserPage = () => {
 
   //どのタブが現在アクティブであるかを管理している。
   //ユーザーが切り替えたタブを追跡し、表示するコンテンツを更新する
-  const handleChange = (event, newValue) => {  
-    setValue(newValue); 
-  };
+  // const handleChange = (event, newValue) => {  
+  //   setValue(newValue); 
+  // };
 
   const handleCardClick = (profile) => {
     router.push(`/users/profiles/${profile.uuid}`);
@@ -150,12 +150,12 @@ const UserPage = () => {
       </TableContainer>
     </Box>
 
-    <Tabs value={value} onChange={handleChange} centered>
+    {/* <Tabs value={value} onChange={handleChange} centered>
       <Tab  label="プロフィール帳" />
       <Tab label="お気に入り" />
-    </Tabs>
+    </Tabs> */}
 
-    <TabPanel value={value} index={0}>
+    {/* <TabPanel value={value} index={0}> */}
       <CardContent>
       {isLoading ? (
         <Skeleton variant="rectangular" width={280} height={180} />
@@ -176,13 +176,13 @@ const UserPage = () => {
         </Grid>
       )}
       </CardContent>
-    </TabPanel>
+    {/* </TabPanel> */}
 
-    <TabPanel value={value} index={1}>
+    {/* <TabPanel value={value} index={1}>
       <CardContent>
         準備中です！
       </CardContent>
-    </TabPanel>
+    </TabPanel> */}
     </>
   );
 };

--- a/src/pages/users/index.js
+++ b/src/pages/users/index.js
@@ -100,9 +100,9 @@ const Users = () => {
           <FormControl sx={{ minWidth: 180 }} size="small">
             <Autocomplete
               id="group-select"
-              value={groups.find((group) => group.id === group)}
+              value={groups.find((g) => g.id === group) || null}
               options={groups}
-              getOptionLabel={(option) => option.name}
+              getOptionLabel={(option) => option ? option.name : ""}
               onChange={(event, newValue) => {
                 setGroup(newValue ? newValue.id : 'RUNTEQ');
               }}

--- a/src/pages/users/index.js
+++ b/src/pages/users/index.js
@@ -11,6 +11,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useRouter } from 'next/router';
 import nookies from "nookies"
 import ReactPaginate from 'react-paginate';
+import { Autocomplete } from '@mui/material';
 
 
 const Users = () => {
@@ -52,15 +53,13 @@ const Users = () => {
   useEffect(() => {
     const fetchGroups = async () => {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/groups/for_community/1`);
-      setGroups(response.data.groups); 
+      const groupsData = response.data.groups;
+      groupsData.unshift({ id: 'RUNTEQ', name: 'みんな' }); // 「みんな」選択肢を追加
+      setGroups(groupsData); 
     };
     fetchGroups();
   }, []);
 
-  
-
-  
-    
   return (
     <div>
       <Box sx={{ display: 'flex', justifyContent: 'center', my: 5 }}>
@@ -85,34 +84,40 @@ const Users = () => {
             style={{ backgroundColor: '#f0f0f0' }}
           />
         </Grid>
-      <Grid item xs={12} sm={"auto"}>
-        <FormControl sx={{ minWidth: 120 }} size="small">
-          <Select 
-            value={sortBy} 
-            onChange={(e) => setSortBy(e.target.value)}
-            style={{backgroundColor: '#f0f0f0' }}
-          >
-            <MenuItem value="created_at_desc">新着順</MenuItem>
-            <MenuItem value="name_asc">名前順</MenuItem>
-          </Select>
-        </FormControl>
-      </Grid>
-      <Grid item xs={12} sm={"auto"}>
-        <FormControl sx={{minWidth: 120 }} size="small">
-          <Select 
-            value={group} 
-            onChange={(e) => setGroup(e.target.value)}
-            style={{backgroundColor: '#f0f0f0' }}
-          >
-            <MenuItem value='RUNTEQ'>みんな</MenuItem>  
-            {groups.map((group) => ( // 取得したグループデータをもとに選択肢を動的に生成
-              <MenuItem key={group.id} value={group.id}>{group.name}</MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <Grid item xs={12} sm={"auto"}>
+          <FormControl sx={{ minWidth: 120 }} size="small">
+            <Select 
+              value={sortBy} 
+              onChange={(e) => setSortBy(e.target.value)}
+              style={{backgroundColor: '#f0f0f0' }}
+            >
+              <MenuItem value="created_at_desc">新着順</MenuItem>
+              <MenuItem value="name_asc">名前順</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={"auto"}>
+          <FormControl sx={{ minWidth: 180 }} size="small">
+            <Autocomplete
+              id="group-select"
+              value={groups.find((group) => group.id === group)}
+              options={groups}
+              getOptionLabel={(option) => option.name}
+              onChange={(event, newValue) => {
+                setGroup(newValue ? newValue.id : 'RUNTEQ');
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  size="small"
+                  label="グループ"
+                  style={{ backgroundColor: '#f0f0f0' }}
+                />
+              )}
+            />
+          </FormControl>
         </Grid>
       </Grid>
-
       <TableContainer component={Paper}>
         <Table>
           <TableHead>
@@ -166,6 +171,7 @@ const Users = () => {
               padding: 1,
               borderRadius: 1,
               cursor: 'pointer',
+              fontWeight: 'bold', 
               '&.active': {
                 backgroundColor: '#ffaf95',
               },

--- a/src/pages/users/profiles/[id].js
+++ b/src/pages/users/profiles/[id].js
@@ -4,10 +4,10 @@ import { Button, Box, CardMedia, CardContent, Grid, Card, IconButton, Skeleton, 
 import { styled } from '@mui/system';
 import nookies from "nookies";
 import axios from 'axios';
-import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
-import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
-import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
-import Tooltip from '@mui/material/Tooltip';
+// import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
+// import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
+// import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
+// import Tooltip from '@mui/material/Tooltip';
 import CenteredBox from '../../../components/CenteredBox'
 
 const StyledCard = styled(Card)(({ theme }) => ({ 
@@ -25,10 +25,10 @@ const StyledCardMedia = styled(CardMedia)(({ theme }) => ({
   objectFit: 'contain',
 }));
 
-const IconCard = styled(Card)(({ theme }) => ({
-  display: 'inline-flex',
-  alignItems: 'flex',  
-}));
+// const IconCard = styled(Card)(({ theme }) => ({
+//   display: 'inline-flex',
+//   alignItems: 'flex',  
+// }));
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -37,9 +37,9 @@ export default function ProfilePage() {
   const [loading, setLoading] = useState(true);
   const [profileImage, setProfileImage] = useState('');
 
-  const [openModalHeart, setOpenModalHeart] = useState(false);
-  const [openModalStar, setOpenModalStar] = useState(false);
-  const [openModalChat, setOpenModalChat] = useState(false);
+  // const [openModalHeart, setOpenModalHeart] = useState(false);
+  // const [openModalStar, setOpenModalStar] = useState(false);
+  // const [openModalChat, setOpenModalChat] = useState(false);
 
   
   useEffect(() => {
@@ -65,21 +65,21 @@ export default function ProfilePage() {
     router.push(`/users/${profileImage.user_id}`); 
   };
   
-  const handleOpenModalStar = () => {
-    setOpenModalStar(true);
-  };
+  // const handleOpenModalStar = () => {
+  //   setOpenModalStar(true);
+  // };
   
-  const handleCloseModalStar = () => {
-    setOpenModalStar(false);
-  };
+  // const handleCloseModalStar = () => {
+  //   setOpenModalStar(false);
+  // };
   
-  const handleOpenModalChat = () => {
-    setOpenModalChat(true);
-  };
+  // const handleOpenModalChat = () => {
+  //   setOpenModalChat(true);
+  // };
   
-  const handleCloseModalChat = () => {
-    setOpenModalChat(false);
-  };
+  // const handleCloseModalChat = () => {
+  //   setOpenModalChat(false);
+  // };
   
   return (
     <>
@@ -92,7 +92,7 @@ export default function ProfilePage() {
             <StyledCardMedia component="img" image={profileImage.image_url} />
           )}
         </StyledCard>
-        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        {/* <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <IconCard>
             <Tooltip title="いいね">
               <IconButton>
@@ -110,7 +110,7 @@ export default function ProfilePage() {
               </IconButton>
             </Tooltip>
           </IconCard>
-        </Box>
+        </Box> */}
         <CenteredBox>
           <Button 
             type="submit"
@@ -136,7 +136,7 @@ export default function ProfilePage() {
         </CenteredBox>
       </Grid>
     </CardContent>   
-
+{/* 
   <Modal
     open={openModalStar}
     onClose={handleCloseModalStar}
@@ -171,7 +171,7 @@ export default function ProfilePage() {
       }}>
          準備中です！
      </Box>
-    </Modal>
+    </Modal> */}
     </>
   );
 }


### PR DESCRIPTION
# 説明
・ユーザー一覧画面のグループのセレクトフォームについて選択肢が画面いっぱいに広がっていたのをスクロールできる形に変更しました。また、ワード検索も合わせてできるフォームに変更しています。
・マイページ編集画面のグループのセレクトフォームについて、選択肢が画面いっぱいに広がっていたのをスクロールできる形に変更しました。
・ユーザーのプロフィール帳詳細画面のアイコンを削除しました。
・マイページのプロフィール帳の詳細画面のハートとスターと吹き出しのアイコンを削除しました。

# 確認したこと
ローカルでは期待した画面表示となっていることを確認しました。
